### PR TITLE
Release 1.2.1

### DIFF
--- a/net.mkiol.SpeechNote.Addon.nvidia.metainfo.xml
+++ b/net.mkiol.SpeechNote.Addon.nvidia.metainfo.xml
@@ -20,6 +20,13 @@
   <url type="bugtracker">https://github.com/mkiol/dsnote/issues</url>
   <update_contact>dsnote_AT_mkiol.net</update_contact>
   <releases>
+    <release version="1.2.1" date="2024-08-15">
+      <description>
+        <ul>
+        <li>AVX2 and FMA are no longer required to run WhisperCpp when using GPU acceleration.</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.2.0" date="2024-06-15">
       <description>
         <ul>

--- a/net.mkiol.SpeechNote.Addon.nvidia.yaml
+++ b/net.mkiol.SpeechNote.Addon.nvidia.yaml
@@ -87,6 +87,8 @@ modules:
       - -DWHISPER_BUILD_TESTS=OFF
       - -DWHISPER_BUILD_EXAMPLES=OFF
       - -DWHISPER_CUDA=ON
+      - -DWHISPER_NO_AVX2=ON
+      - -DWHISPER_NO_FMA=ON
       - -DWHISPER_TARGET_NAME=whisper-cublas
       - -DCMAKE_C_FLAGS='-O3'
       - -DCMAKE_CXX_FLAGS='-O3'

--- a/patches/whispercpp.patch
+++ b/patches/whispercpp.patch
@@ -18,7 +18,7 @@ diff -ruN whispercpp-1.6.2-org/cmake/DefaultTargetOptions.cmake whispercpp-1.6.2
  )
 diff -ruN whispercpp-1.6.2-org/CMakeLists.txt whispercpp-1.6.2-patched/CMakeLists.txt
 --- whispercpp-1.6.2-org/CMakeLists.txt	2024-05-27 09:35:09.000000000 +0200
-+++ whispercpp-1.6.2-patched/CMakeLists.txt	2024-05-28 18:39:24.101390460 +0200
++++ whispercpp-1.6.2-patched/CMakeLists.txt	2024-05-28 18:39:42.924731063 +0200
 @@ -248,91 +248,11 @@
  if (WHISPER_OPENBLAS)
      set(WHISPER_BLAS_VENDOR "OpenBLAS")
@@ -188,3 +188,67 @@ diff -ruN whispercpp-1.6.2-org/CMakeLists.txt whispercpp-1.6.2-patched/CMakeList
      RUNTIME  DESTINATION bin
      RESOURCE DESTINATION bin
      PUBLIC_HEADER DESTINATION include
+diff -ruN whispercpp-1.6.2-org/ggml-cuda.cu whispercpp-1.6.2-patched/ggml-cuda.cu
+--- whispercpp-1.6.2-org/ggml-cuda.cu	2024-05-27 09:35:09.000000000 +0200
++++ whispercpp-1.6.2-patched/ggml-cuda.cu	2024-08-01 19:15:24.155033047 +0200
+@@ -83,7 +83,7 @@
+ #ifdef __HIP_PLATFORM_AMD__
+     // Workaround for a rocBLAS bug when using multiple graphics cards:
+     // https://github.com/ROCmSoftwarePlatform/rocBLAS/issues/1346
+-    rocblas_initialize();
++    // rocblas_initialize();
+     CUDA_CHECK(cudaDeviceSynchronize());
+ #endif
+ 
+diff -ruN whispercpp-1.6.2-org/ggml-impl.h whispercpp-1.6.2-patched/ggml-impl.h
+--- whispercpp-1.6.2-org/ggml-impl.h	2024-05-27 09:35:09.000000000 +0200
++++ whispercpp-1.6.2-patched/ggml-impl.h	2024-07-10 20:22:17.059805494 +0200
+@@ -366,18 +366,44 @@
+ 
+ #define ggml_int16x8x2_t  int16x8x2_t
+ #define ggml_uint8x16x2_t uint8x16x2_t
+-#define ggml_uint8x16x4_t uint8x16x4_t
+ #define ggml_int8x16x2_t  int8x16x2_t
+-#define ggml_int8x16x4_t  int8x16x4_t
+ 
+ #define ggml_vld1q_s16_x2 vld1q_s16_x2
+ #define ggml_vld1q_u8_x2  vld1q_u8_x2
+-#define ggml_vld1q_u8_x4  vld1q_u8_x4
+ #define ggml_vld1q_s8_x2  vld1q_s8_x2
+-#define ggml_vld1q_s8_x4  vld1q_s8_x4
+ #define ggml_vqtbl1q_s8   vqtbl1q_s8
+ #define ggml_vqtbl1q_u8   vqtbl1q_u8
+ 
++typedef struct ggml_int8x16x4_t {
++    int8x16_t val[4];
++} ggml_int8x16x4_t;
++
++inline static ggml_int8x16x4_t ggml_vld1q_s8_x4(const int8_t * ptr) {
++    ggml_int8x16x4_t res;
++
++    res.val[0] = vld1q_s8(ptr + 0);
++    res.val[1] = vld1q_s8(ptr + 16);
++    res.val[2] = vld1q_s8(ptr + 32);
++    res.val[3] = vld1q_s8(ptr + 48);
++
++    return res;
++}
++
++typedef struct ggml_uint8x16x4_t {
++    uint8x16_t val[4];
++} ggml_uint8x16x4_t;
++
++inline static ggml_uint8x16x4_t ggml_vld1q_u8_x4(const uint8_t * ptr) {
++    ggml_uint8x16x4_t res;
++
++    res.val[0] = vld1q_u8(ptr + 0);
++    res.val[1] = vld1q_u8(ptr + 16);
++    res.val[2] = vld1q_u8(ptr + 32);
++    res.val[3] = vld1q_u8(ptr + 48);
++
++    return res;
++}
++
+ #endif // !defined(__aarch64__)
+ 
+ #if !defined(__ARM_FEATURE_DOTPROD)


### PR DESCRIPTION
Changes:

- AVX2 and FMA are no longer required to run WhisperCpp when using GPU acceleration.